### PR TITLE
Intern optional registry

### DIFF
--- a/loader_kafka/__init__.py
+++ b/loader_kafka/__init__.py
@@ -117,7 +117,7 @@ def derive_records_topic_name(config, stream_name):
 def derive_state_topic_name(config):
     return config["topic_prefix"] + ".state"
 
-def derive_schema_topic_name(config, stream_name): 
+def derive_schema_topic_name(config, stream_name):
     return config["topic_prefix"] + "." + stream_name + ".schema"
 
 def persist_messages_registry(config, avro_producer, json_producer, kafka_consumer, admin_client, messages):

--- a/loader_kafka/__init__.py
+++ b/loader_kafka/__init__.py
@@ -112,7 +112,6 @@ def create_topic_as_needed(config, kafka_consumer, admin_client, stream_name, to
             logger.debug("Target topic already exists.")
 
 def derive_records_topic_name_registry(config, stream_name):
-    logger.info("records registry")
     return config["topic_prefix"] + "." + stream_name + ".records"
 
 def derive_records_topic_name_raw(config):
@@ -178,9 +177,9 @@ def persist_messages_raw(config, json_producer, kafka_consumer, admin_client, me
             stream_name = o['stream']
 
             # Creating the records topic here for efficiency
-            topics = [derive_state_topic_name(config), derive_schema_topic_name(config), derive_records_topic_name_raw(config)]
-            create_topic_as_needed(config, kafka_consumer, admin_client, stream_name, topics)
             topic = derive_schema_topic_name(config)
+            topics = [derive_state_topic_name(config), topic, derive_records_topic_name_raw(config)]
+            create_topic_as_needed(config, kafka_consumer, admin_client, stream_name, topics)
 
         elif o['type'] == "RECORD":
             topic = derive_records_topic_name_raw(config)

--- a/loader_kafka/__init__.py
+++ b/loader_kafka/__init__.py
@@ -175,7 +175,7 @@ def persist_messages_raw(config, json_producer, kafka_consumer, admin_client, me
 
             # Creating the records topic here for efficiency
             topic = derive_schema_topic_name(config, stream_name)
-            topics = [derive_state_topic_name(config), topic, derive_records_topic_name(config)]
+            topics = [derive_state_topic_name(config), topic, derive_records_topic_name(config, stream_name)]
             create_topic_as_needed(config, kafka_consumer, admin_client, stream_name, topics)
 
         elif o['type'] == "RECORD":

--- a/loader_kafka/__init__.py
+++ b/loader_kafka/__init__.py
@@ -100,24 +100,35 @@ def convert_dates_to_avro(date_fields, record):
         if type(v) == dict:
             convert_dates_to_avro(date_fields, v)
 
-
-def create_topic_as_needed(config, kafka_consumer, admin_client, topic):
+def create_topic_as_needed(config, kafka_consumer, admin_client, stream_name, include_schema):
     logger.debug("Checking for target topic existence.")
-    if topic not in kafka_consumer.topics():
-        logger.info(f"Creating topic {topic}")
-        topic_list = [NewTopic(name=topic, num_partitions=config.get('topic_partitions', 1), replication_factor=config.get('topic_replication', 1))]
-        admin_client.create_topics(new_topics=topic_list, validate_only=False)
-    else:
-        logger.debug("Target topic already exists.")
 
-def derive_records_topic_name(config, stream_name):
+    topics = [derive_records_topic_name_registry(config, stream_name), derive_state_topic_name(config)]
+
+    if include_schema:
+        topics.append(derive_schema_topic_name(config))
+
+    for topic in topics:
+        if topic not in kafka_consumer.topics():
+            logger.info(f"Creating topic {topic}")
+            topic_list = [NewTopic(name=topic, num_partitions=config.get('topic_partitions', 1), replication_factor=config.get('topic_replication', 1))]
+            admin_client.create_topics(new_topics=topic_list, validate_only=False)
+        else:
+            logger.debug("Target topic already exists.")
+
+def derive_records_topic_name_registry(config, stream_name):
     return config["topic_prefix"] + "." + stream_name + ".records"
+
+def derive_records_topic_name_raw(config):
+    return config["topic_prefix"] + ".records"
 
 def derive_state_topic_name(config):
     return config["topic_prefix"] + ".state"
 
+def derive_schema_topic_name(config):
+    return config["topic_prefix"] + ".schema"
 
-def persist_messages(config, avro_producer, json_producer, kafka_consumer, admin_client, messages):
+def persist_messages_registry(config, avro_producer, json_producer, kafka_consumer, admin_client, messages):
     stream_to_date_fields = {}
     stream_to_schema = {}
     unique_per_run = str(uuid.uuid1())
@@ -130,12 +141,12 @@ def persist_messages(config, avro_producer, json_producer, kafka_consumer, admin
             stream_name = o['stream']
             # Convert date fields in the record
             convert_dates_to_avro(stream_to_date_fields[stream_name], o['record'])
-            avro_producer.produce(topic=derive_records_topic_name(config, stream_name), value=o['record'], value_schema=stream_to_schema[stream_name])
+            avro_producer.produce(topic=derive_records_topic_name_registry(config, stream_name), value=o['record'], value_schema=stream_to_schema[stream_name])
 
         elif o['type'] == 'SCHEMA':
             stream_name = o['stream']
             # Creating the records topic here for efficiency
-            create_topic_as_needed(config, kafka_consumer, admin_client, derive_records_topic_name(config, stream_name))
+            create_topic_as_needed(config, kafka_consumer, admin_client, stream_name, False)
 
             avsc_fields, stream_to_date_fields[stream_name] = _avsc(a=o['schema']["properties"])
 
@@ -160,14 +171,39 @@ def persist_messages(config, avro_producer, json_producer, kafka_consumer, admin
 
     avro_producer.flush()
 
+
+def persist_messages_raw(config, json_producer, kafka_consumer, admin_client, messages):
+    unique_per_run = str(uuid.uuid1())
+
+    for idx, message in enumerate(messages):
+        o = json.loads(message)
+        if o['type'] == 'SCHEMA':
+            stream_name = o['stream']
+            # Creating the records topic here for efficiency
+            create_topic_as_needed(config, kafka_consumer, admin_client, stream_name, True)
+            topic = derive_schema_topic_name(config)
+
+        elif o['type'] == "RECORD":
+            topic = derive_records_topic_name_raw(config)
+
+        elif o['type'] == "STATE":
+            topic = derive_state_topic_name(config)
+
+        message_bytes = bytes(message, encoding='utf-8')
+        key_bytes = bytes((unique_per_run+"-"+str(idx)), encoding='utf-8')
+
+        try:
+            json_producer.send(topic, value=message_bytes, key=key_bytes)
+        except Exception as err:
+            logger.error(f"Unable to send a record to kafka:",err)
+            raise err
+
+    json_producer.flush()
+
 def main():
-    args = utils.parse_args()
+    args = utils.parse_args([])  #sophie added
     config = Config.validate(args.config)
 
-    avro_producer = AvroProducer({
-        'bootstrap.servers': config['kafka_brokers'],
-        'schema.registry.url': config['schema_registry_url']
-    })
     json_producer = KafkaProducer(bootstrap_servers=config['kafka_brokers'], retries=3)
     kafka_consumer = KafkaConsumer(bootstrap_servers=config['kafka_brokers'], client_id='loader-kafka')
     admin_client = KafkaAdminClient(
@@ -176,7 +212,18 @@ def main():
     )
 
     input_messages = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-    persist_messages(config, avro_producer, json_producer, kafka_consumer, admin_client, input_messages)
+
+    if 'schema_registry_url' in config and config['schema_registry_url']:
+
+        avro_producer = AvroProducer({
+            'bootstrap.servers': config['kafka_brokers'],
+            'schema.registry.url': config['schema_registry_url']
+        })
+
+        persist_messages_registry(config, avro_producer, json_producer, kafka_consumer, admin_client, input_messages)
+    else:
+        persist_messages_raw(config, json_producer, kafka_consumer, admin_client, input_messages)
+
     json_producer.close()
     kafka_consumer.close()
     admin_client.close()

--- a/loader_kafka/configuration.py
+++ b/loader_kafka/configuration.py
@@ -7,8 +7,8 @@ LOGGER = logging.getLogger(__name__)
 
 CONFIG_CONTRACT = Schema({
     Required('kafka_brokers'): str,
-    Required('schema_registry_url'): str,
     Required('topic_prefix'): str,
+    Optional('schema_registry_url'): str,
     Optional('topic_partitions'): int,
     Optional('topic_replication'): int
 })

--- a/loader_kafka/test/test_loader.py
+++ b/loader_kafka/test/test_loader.py
@@ -59,7 +59,7 @@ class TestFormatHandler(unittest.TestCase):
             # One state message published plus a call to flush
             assert len(json_producer.method_calls) == 2
             # Did we invoke admin client to create the kafka topic as expected?
-            assert len(admin_client.method_calls) == 1
+            assert len(admin_client.method_calls) == 2
 
     def test_schema_registry_url_logic(self):
         config = Config.validate(COMPLETE_TEST_SPEC)
@@ -69,7 +69,6 @@ class TestFormatHandler(unittest.TestCase):
             json_producer = MagicMock()
             class MockTopics:
                 def __init__(self):
-                    LOGGER.info("started")
                     self.topics = []
                 def topics(self):
                     return self.topics

--- a/loader_kafka/test/test_loader.py
+++ b/loader_kafka/test/test_loader.py
@@ -52,3 +52,7 @@ class TestFormatHandler(unittest.TestCase):
             assert len(json_producer.method_calls) == 2
             # Did we invoke admin client to create the kafka topic as expected?
             assert len(admin_client.method_calls) == 1
+    
+    def test_schema_registry_url_logic(self):
+        config = Config.validate(COMPLETE_TEST_SPEC)
+        test_filename_uri = './loader_kafka/test/tap_output.json'

--- a/loader_kafka/test/test_loader.py
+++ b/loader_kafka/test/test_loader.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from loader_kafka import Config, persist_messages, convert_dates_to_avro
+from loader_kafka import Config, persist_messages_raw, persist_messages_registry, convert_dates_to_avro
 
 COMPLETE_TEST_SPEC = {
     "kafka_brokers": "http://localhost:4242",
@@ -45,7 +45,7 @@ class TestFormatHandler(unittest.TestCase):
                     return ["pre-existing-topic"]
             kafka_consumer = MagicMock(spec=MockTopics)
             admin_client = MagicMock()
-            persist_messages(config, avro_producer, json_producer, kafka_consumer, admin_client, messages)
+            persist_messages_registry(config, avro_producer, json_producer, kafka_consumer, admin_client, messages)
             # 1999 records published plus one call to flush
             assert len(avro_producer.method_calls) == 2000
             # One state message published plus a call to flush
@@ -64,7 +64,8 @@ class TestFormatHandler(unittest.TestCase):
                     return ["pre-existing-topic"]
             kafka_consumer = MagicMock(spec=MockTopics)
             admin_client = MagicMock()
-            persist_messages(config, avro_producer, json_producer, kafka_consumer, admin_client, messages)
+            persist_messages_registry(config, avro_producer, json_producer, kafka_consumer, admin_client, messages)
             expected_topics = ["qualytics.topics.orders.records","qualytics.topics.state"]
             for topic in expected_topics:
                 assert(topic in kafka_consumer.topics())
+            assert("qualytics.topics.orders.schema" in kafka_consumer.topics())

--- a/loader_kafka/test/test_loader.py
+++ b/loader_kafka/test/test_loader.py
@@ -52,7 +52,19 @@ class TestFormatHandler(unittest.TestCase):
             assert len(json_producer.method_calls) == 2
             # Did we invoke admin client to create the kafka topic as expected?
             assert len(admin_client.method_calls) == 1
-    
+
     def test_schema_registry_url_logic(self):
         config = Config.validate(COMPLETE_TEST_SPEC)
         test_filename_uri = './loader_kafka/test/tap_output.json'
+        with open(test_filename_uri, 'r') as messages:
+            avro_producer = MagicMock()
+            json_producer = MagicMock()
+            class MockTopics:
+                def topics(self):
+                    return ["pre-existing-topic"]
+            kafka_consumer = MagicMock(spec=MockTopics)
+            admin_client = MagicMock()
+            persist_messages(config, avro_producer, json_producer, kafka_consumer, admin_client, messages)
+            expected_topics = ["qualytics.topics.orders.records","qualytics.topics.state"]
+            for topic in expected_topics:
+                assert(topic in kafka_consumer.topics())


### PR DESCRIPTION
Three things to note:

1) When running a Meltano elt with loader-kafka, we were getting an error on line 202 that parse_args was missing an argument. We just sent an empty array through to get past this, but wanted to flag in case you want to drop that. The error is commented in the code. 

2) It looks like the master version only creates the records topic dynamically (not state). We changed it so that upon a schema message, topics are potentially created for records, state, and (if raw json) schema. 

3) We noticed when the message's stream name contain a hyphen (for ex, "qualytics-stream", an exception is thrown when the avro schema is loaded (line 154). Underscores don't cause this problem, only hyphens. 